### PR TITLE
Add instructions for vscode

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ Add the following elisp code to your configuration. (using `use-package`)
   (nix-mode . eglot-ensure))
 ```
 
+### For vscode `Nix IDE` user
+
+Modify the extension's settings in your `settings.json`
+
+```jsonc
+{
+  // ...
+  "nix.serverPath": "nil"
+}
+```
+
 ## License
 
 "nil" is primarily distributed under the terms of both the MIT


### PR DESCRIPTION
Everything seems to work fine in VS Code, by using the existing "Nix IDE" extension and just setting the correct binary.

It might be useful to mention it in the readme.