### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/oxalica/nil/actions/workflows/ci.yml/badge.svg)](https://github.com/oxalica/nil/actions/workflows/ci.yml)
 
-An incremental analysis assistent for writing in Nix.
+An incremental analysis assistant for writing in Nix.
 
 See [release notes][releases] for change log between tagged unstable versions.
 
@@ -37,8 +37,8 @@ run `nix profile install github:oxalica/nil` to get `nil` installed.
 You can also use this repository as a flake input and add its output to your own flake-managed
 systemwide or home configuration.
 
-*Disclamer: We ship `flake.lock` which is tested in CI to be working. If you use `follows` to
-override flake inputs, we provides no guarentee of whether it would still build.*
+*Disclaimer: We ship `flake.lock` which is tested in CI to be working. If you use `follows` to
+override flake inputs, we provide no guarantee of whether it would still build.*
 
 Flake output structure (not necessary up-to-date):
 ```


### PR DESCRIPTION
Hey there,

Thanks for your work on `nil`! I've been using it for a while now and it is :pinched_fingers: fantastic. I just saw yesterday's release adds go-to definition support for flake inputs, neat! Go-to definition is the biggest feature I miss with Nix LSPs, so I'm happy to see this feature.

Anyway, I saw these minor typos on the readme and figured I'd open a PR.

Cheers!