### PR TITLE
Fix and improve types for flake outputs

### DIFF
--- a/crates/ide/src/ty/known.rs
+++ b/crates/ide/src/ty/known.rs
@@ -115,8 +115,10 @@ pub fn flake(inputs: &[&str]) -> Ty {
                 }
             },
             "devShells": {
-                "default": derivation,
-                _: derivation
+                _: {
+                    "default": derivation,
+                    _: derivation
+                }
             },
             "formatter": {
                 _: derivation
@@ -143,8 +145,10 @@ pub fn flake(inputs: &[&str]) -> Ty {
                 _: ({ } -> { } -> { })
             },
             "packages": {
-                "default": derivation,
-                _: derivation
+                _: {
+                    "default": derivation,
+                    _: derivation
+                }
             },
             "templates": {
                 "default": { "description": string, "path": string },

--- a/crates/ide/src/ty/known.rs
+++ b/crates/ide/src/ty/known.rs
@@ -104,36 +104,47 @@ pub fn flake(inputs: &[&str]) -> Ty {
         // https://nixos.org/manual/nix/unstable/command-ref/new-cli/nix3-develop.html?highlight=flake#flake-output-attributes
         "outputs": ((#outputs_param_ty) -> {
             "apps": {
+                // System
                 _: {
                     "default": { "type": string, "program": string },
+                    // Name
                     _: { "type": string, "program": string }
                 }
             },
             "checks": {
+                // System
                 _: {
+                    // Name
                     _: derivation
                 }
             },
             "devShells": {
+                // System
                 _: {
                     "default": derivation,
+                    // Name
                     _: derivation
                 }
             },
             "formatter": {
+                // System
                 _: derivation
             },
             "hydraJobs": {
+                // Name
                 _: {
+                    // System
                     _: derivation
                 }
             },
             "legacyPackages": {
+                // System
                 _: {
                     _: ?
                 }
             },
             "nixosConfigurations": {
+                // Name
                 _: {
                     "config": { },
                     "extendModules":
@@ -150,20 +161,25 @@ pub fn flake(inputs: &[&str]) -> Ty {
             },
             "nixosModules": {
                 "default": ({ "config": { } } -> { "options": { }, "config": { } }),
+                // Name
                 _: ({ "config": { } } -> { "options": { }, "config": { } })
             },
             "overlays": {
                 "default": ({ } -> { } -> { }),
+                // Name
                 _: ({ } -> { } -> { })
             },
             "packages": {
+                // System
                 _: {
                     "default": derivation,
+                    // Name
                     _: derivation
                 }
             },
             "templates": {
                 "default": { "description": string, "path": string },
+                // Name
                 _: { "description": string, "path": string }
             },
         }),

--- a/crates/ide/src/ty/known.rs
+++ b/crates/ide/src/ty/known.rs
@@ -134,7 +134,19 @@ pub fn flake(inputs: &[&str]) -> Ty {
                 }
             },
             "nixosConfigurations": {
-                _: derivation
+                _: {
+                    "config": { },
+                    "extendModules":
+                        ({
+                            "modules": [?],
+                            "specialArgs": { },
+                            "prefix": [string]
+                        } -> { }),
+                    "extraArgs": { },
+                    "options": { },
+                    "pkgs": { },
+                    "type": { }
+                }
             },
             "nixosModules": {
                 "default": ({ "config": { } } -> { "options": { }, "config": { } }),


### PR DESCRIPTION
nil was giving me questionable completions - `packages.default` is not supposed to be a derivation, `packages.${system}.default` is. This PR fixes this issue for `packages` and `devShells`, and also fixes and improves types for `nixosConfigurations`. I wasn't able to get completion working correctly, but that seems to be a separate issue since I also couldn't get `inputs.*.inputs.*` to complete `follows`