### PR TITLE
Check if workspace/configuration is supported

### DIFF
--- a/crates/nil/src/capabilities.rs
+++ b/crates/nil/src/capabilities.rs
@@ -48,6 +48,7 @@ pub(crate) fn negotiate_capabilities(
                     .did_change_watched_files
                     .relative_pattern_support
             ),
+        workspace_configuration: test!(client_caps.workspace.configuration),
     };
 
     let server_caps = ServerCapabilities {
@@ -103,4 +104,5 @@ pub(crate) struct NegotiatedCapabilities {
     pub server_initiated_progress: bool,
     pub watch_files: bool,
     pub watch_files_relative_pattern: bool,
+    pub workspace_configuration: bool,
 }

--- a/crates/nil/src/server.rs
+++ b/crates/nil/src/server.rs
@@ -753,6 +753,9 @@ impl Server {
     }
 
     fn spawn_reload_config(&self) {
+        if !self.capabilities.workspace_configuration {
+            return;
+        }
         let mut client = self.client.clone();
         tokio::spawn(async move {
             let ret = client


### PR DESCRIPTION
Don't send it to clients (like LanguageClient-neovim) that don't support it to avoid error noise.