### PR TITLE
Condition always evaluates to true

### DIFF
--- a/crates/nil/src/server.rs
+++ b/crates/nil/src/server.rs
@@ -362,7 +362,7 @@ impl Server {
     fn on_did_change_watched_files(&mut self, params: DidChangeWatchedFilesParams) -> NotifyResult {
         tracing::debug!("Watched files changed: {params:?}");
 
-        let mut flake_files_changed = true;
+        let mut flake_files_changed = false;
         for &FileEvent { ref uri, mut typ } in &params.changes {
             // Don't reload files maintained by the client.
             if self.opened_files.contains_key(uri) {


### PR DESCRIPTION
I believe this is a typo since 'flake_files_changed' should probably be initialised to false for the condition to 'spawn_load_flake_workspaces' to make any sense.