### PR TITLE
Rewording warning message

### DIFF
--- a/crates/nil/src/server.rs
+++ b/crates/nil/src/server.rs
@@ -492,7 +492,7 @@ impl Server {
                             typ: MessageType::INFO,
                             message: "\
                             Some flake inputs are not available. Fetch them now? \n\
-                            You can enable auto-fetch in configurations.\
+                            You can enable autoArchive in lsp configuration.\
                         "
                             .into(),
                             actions: Some(vec![
@@ -520,7 +520,7 @@ impl Server {
                         MessageType::WARNING,
                         "\
                         Some flake inputs are not available, please run `nix flake archive` to fetch them. \n\
-                        Your LSP client doesn't support confirmation. You can enable auto-fetch in configurations.\
+                        Your LSP client doesn't support confirmation. You can enable autoArchive in lsp configuration.\
                         ",
                     );
                     false


### PR DESCRIPTION
It took me a while to find out what auto-fetch actually means from my lsp client log. There's no such thing as auto-fetch, it's autoArhive.

Somebody else entered this as well. https://www.reddit.com/r/neovim/comments/14pk1u5/lsp_tells_me_to_enable_autofetch_in/