### PR TITLE
Fix tests for nix 2.17

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,15 +47,11 @@ jobs:
         uses: cachix/install-nix-action@v22
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          nix_path: nixpkgs=channel:nixos-unstable
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.channel }}
+          nix_path: nixpkgs=channel:nixpkgs-unstable
       - name: Build
-        run: cargo build --all
+        run: nix develop .#full --command cargo build --all
       - name: Test
-        run: cargo test --all -- --include-ignored
+        run: nix develop .#full --command cargo test --all -- --include-ignored
 
   nix-flake:
     name: Flake package

--- a/crates/ide/src/ide/hover.rs
+++ b/crates/ide/src/ide/hover.rs
@@ -338,7 +338,19 @@ mod tests {
                 `bool`
 
                 `builtins.true`
-                (No documentation from Nix)
+                Primitive value.
+
+                It can be returned by
+                [comparison operators](@docroot@/language/operators.md#Comparison)
+                and used in
+                [conditional expressions](@docroot@/language/constructs.md#Conditionals).
+
+                The name `true` is not special, and can be shadowed:
+
+                ```nix-repl
+                nix-repl> let true = 1; in true
+                1
+                ```
             "#]],
         );
         check(
@@ -419,7 +431,19 @@ mod tests {
                 `bool`
 
                 `builtins.true`
-                (No documentation from Nix)
+                Primitive value.
+
+                It can be returned by
+                [comparison operators](@docroot@/language/operators.md#Comparison)
+                and used in
+                [conditional expressions](@docroot@/language/constructs.md#Conditionals).
+
+                The name `true` is not special, and can be shadowed:
+
+                ```nix-repl
+                nix-repl> let true = 1; in true
+                1
+                ```
             "#]],
         );
 
@@ -434,7 +458,14 @@ mod tests {
                 `{ abort: string → ?, add: float → float → float, addErrorContext: string → ? → ?, all: (? → bool) → [?] → bool, … }`
 
                 `builtins.builtins`
-                (No documentation from Nix)
+                Contains all the [built-in functions](@docroot@/language/builtins.md) and values.
+
+                Since built-in functions were added over time, [testing for attributes](./operators.md#has-attribute) in `builtins` can be used for graceful fallback on older Nix installations:
+
+                ```nix
+                # if hasContext is not available, we assume `s` has a context
+                if builtins ? hasContext then builtins.hasContext s else true
+                ```
             "#]],
         );
     }

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688829822,
-        "narHash": "sha256-hv56yK1fPHPt7SU2DboxBtdSbIuv9nym7Dss7Cn2jic=",
+        "lastModified": 1690441914,
+        "narHash": "sha256-Ac+kJQ5z9MDAMyzSc0i0zJDx2i3qi9NjlW5Lz285G/I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ed6afb10dfdfc97b6bcf0703f1bad8118e9e961b",
+        "rev": "db8672b8d0a2593c2405aed0c1dfa64b2a2f428f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates nixpkgs so nil builds with nix 2.17 and fixes the test expectations.