### PR TITLE
nix-interop: fix option completion of `types.attrsOf (types.submodule {})`

### DIFF
--- a/crates/nix-interop/src/nixos_options.nix
+++ b/crates/nix-interop/src/nixos_options.nix
@@ -104,8 +104,8 @@ let
 
       listOf = { name = "list"; inherit elem; };
 
-      attrOf = { name = "attrset"; rest = elem; };
-      lazyAttrOf = { name = "attrset"; rest = elem; };
+      attrsOf = { name = "attrset"; rest = elem; };
+      lazyAttrsOf = { name = "attrset"; rest = elem; };
 
       uniq = elem;
       unique = elem;


### PR DESCRIPTION
a.k.a. fix a small typo.

Because the type-name `attrsOf` was never matched, e.g. `systemd.services` always had type `any`.

cc @oxalica 