### PR TITLE
Fail textDocument/formatting when no formatter is set

### DIFF
--- a/crates/nil/src/handler.rs
+++ b/crates/nil/src/handler.rs
@@ -221,9 +221,10 @@ pub(crate) fn formatting(
         Ok(stdout)
     }
 
-    let Some(cmd) = &snap.config.formatting_command else {
-        return Ok(None);
-    };
+    let cmd =
+        snap.config.formatting_command.as_ref().context(
+            "No formatter configured. Set the nil.formatting.command LSP server setting.",
+        )?;
 
     let (file_content, line_map) = {
         let vfs = snap.vfs();


### PR DESCRIPTION
Currently, nil silently fails when no formatter is set. This caused me a lot of confusion as to why nothing was formatting when I accidentally misconfigured the formatter.

This makes it so that we return an error instead, alerting the user that something is wrong.

This could be annoying to someone who hasn't configured a formatter on purpose but still causes formatting events, either by format-on-save or muscle memory. I think this is fine, and they should turn off format-on-save or just get a formatter instead. Alternatively, someone could set `cat` as their formatter.

![image](https://github.com/oxalica/nil/assets/48135649/12f92da2-c8c5-48d5-8129-73e7de618694)
> [Error - 8:02:06 PM] Request textDocument/formatting failed.
>  Message: No formatter configured. Set the nil.formatting.command LSP server setting.
>  Code: -32603 