### PR TITLE
Fix liveness warnings for __findFile

### DIFF
--- a/crates/ide/src/def/liveness.rs
+++ b/crates/ide/src/def/liveness.rs
@@ -252,6 +252,7 @@ mod tests {
     #[test]
     fn lambda() {
         check("a: { b }: $0c@{}: 0");
+        check("let __findFile = a: b: 1; in <findme>");
     }
 
     #[test]

--- a/crates/ide/src/def/lower.rs
+++ b/crates/ide/src/def/lower.rs
@@ -709,6 +709,16 @@ mod tests {
                 PathData { anchor: Search("p"), supers: 2, relative_path: ".b/c" }
             "#]],
         );
+        check_lower(
+            r#"<something>"#,
+            expect![[r#"
+            0: Reference("__findFile")
+            1: List([])
+            2: Apply(Idx::<Expr>(0), Idx::<Expr>(1))
+            3: Literal(Path(Path(0)))
+            4: Apply(Idx::<Expr>(2), Idx::<Expr>(3))
+            "#]],
+        );
     }
 
     #[test]

--- a/crates/syntax/src/parser.rs
+++ b/crates/syntax/src/parser.rs
@@ -469,7 +469,27 @@ impl<'i> Parser<'i> {
                 self.bump(); // IDENT
                 self.finish_node();
             }
-            Some(k @ (INT | FLOAT | PATH | SEARCH_PATH | URI)) => {
+            Some(SEARCH_PATH) => {
+                // Desugaring search path into a __findFile call
+                self.start_node(APPLY);
+                self.start_node(APPLY);
+
+                self.start_node(REF);
+                self.builder.token(SyntaxKind::IDENT.into(), "__findFile");
+                self.finish_node();
+
+                self.start_node(LIST);
+                self.finish_node();
+
+                self.finish_node();
+
+                self.start_node(LITERAL);
+                self.bump();
+                self.finish_node();
+
+                self.finish_node()
+            }
+            Some(k @ (INT | FLOAT | PATH | URI)) => {
                 if k == PATH {
                     self.validate_path_fragment(false);
                 }


### PR DESCRIPTION
Search paths desugar to calling __findFile in Nix.

This fixes warnings in `let __findFile = a: b: "hi ${b}!"; in <gilbert>` 

List parameter is added cause __findFile receives one (with NIXPATH or error thunk). Might be useful for type inference.

I am not sure, if accounting for such a hack is in scope of this lsp, but I've seen it being used and I am using it myself.

- [ ] Fix "Undefined name"
- [ ] Fix broken search path highlight ranges