### PR TITLE
Fix `nil diagnostics` exit code

### DIFF
--- a/crates/nil/src/main.rs
+++ b/crates/nil/src/main.rs
@@ -139,7 +139,7 @@ fn main_diagnostics(args: DiagnosticsArgs) {
             if max_severity > Severity::Warning {
                 process::exit(1)
             } else {
-                process::exit(0)
+                process::exit(2)
             }
         }
         Err(err) => {


### PR DESCRIPTION
`nil diagnostics --help` states:

> Exit with non-zero code if there are any diagnostics. (`1` for errors,
> `2` if only warnings)

In practice, `nil` would only exit with code 1 if there were errors, and if warnings were present it would exit with code 0.