### PR TITLE
Enable `nil diagnostics` for multiple files

### DIFF
--- a/crates/nil/src/main.rs
+++ b/crates/nil/src/main.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use anyhow::{Context, Result};
 use argh::FromArgs;
 use codespan_reporting::diagnostic::Severity;
@@ -138,7 +139,7 @@ fn main_diagnostics(args: DiagnosticsArgs) {
 fn diagnostics_for_files(paths: Vec<PathBuf>) -> Result<Option<ide::Severity>> {
     use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
     if paths.is_empty() {
-        unreachable!();
+        return Err(anyhow!("No files given"));
     }
 
     let mut sources = Vec::new();


### PR DESCRIPTION
Closes #124.

This is the naive approach, which does not attempt to read files or compute diagnostics in parallel (unless there's some `salsa` magic I don't understand happening under the hood).

I was expecting this to be pretty slow, but on a codebase with 234 Nix files comprising 14,000 LOC, `nil diagnostics **/*.nix` completes in 33ms. (Compare this to `parallel --max-args 1 nil diagnostics ::: **/*.nix`, which takes a full 4 seconds.)

If we try `nil diagnostics **/*.nix` in `nixpkgs`, we get:

```
exec: Failed to execute process 'nil': the total size of the argument list and exported variables (1.5MB) exceeds the OS limit of 1MB.
```

Which was to be expected. Using `find` to execute `nil diagnostics` with as many arguments as possible (`find . -path '*.nix' -exec nil diagnostics {} +`) completes in just 6.5 seconds! (That's to analyze 32,800 files containing 3 million LOC.)

The comparable command for one-invocation-per-file (`find . -path '*.nix' | parallel --pipe --cat -L 1 --max-args 1 nil diagnostics {}`) takes... well, it's still running.