### PR TITLE
Discover all `.nix` files in `nil diagnostics`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "bstr"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "builtin"
 version = "0.0.0"
 dependencies = [
@@ -437,6 +447,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +529,22 @@ name = "if_chain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
+
+[[package]]
+name = "ignore"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata 0.4.3",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "indexmap"
@@ -702,6 +741,7 @@ dependencies = [
  "async-lsp",
  "codespan-reporting",
  "ide",
+ "ignore",
  "log",
  "lsp-types",
  "macro_rules_attribute",

--- a/crates/nil/Cargo.toml
+++ b/crates/nil/Cargo.toml
@@ -11,6 +11,7 @@ argh = "0.1.10"
 async-lsp = { version = "0.2.0", features = ["tokio"] }
 codespan-reporting = "0.11.1"
 ide = { path = "../ide" }
+ignore = "0.4.22"
 log = "0.4.17"
 lsp-types = "0.95.0"
 macro_rules_attribute = "0.2.0"

--- a/crates/nil/src/main.rs
+++ b/crates/nil/src/main.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use anyhow::{Context, Result};
 use argh::FromArgs;
 use codespan_reporting::diagnostic::Severity;
@@ -138,7 +139,7 @@ fn main_diagnostics(args: DiagnosticsArgs) {
 fn diagnostics_for_files(paths: Vec<PathBuf>) -> Result<Option<ide::Severity>> {
     use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
     if paths.is_empty() {
-        unreachable!();
+        return Err(anyhow!("No files given"));
     }
 
     let mut sources = Vec::new();


### PR DESCRIPTION
Follow-up to #125.

`nil diagnostics` now accepts directories in addition to files as arguments. If no arguments are given, the current directory (`.`) is used.

The [`ignore`](https://docs.rs/ignore/latest/ignore/) crate is used to traverse the directories and discover files. This is slightly slower than `find . -path '*.nix' -exec nil diagnostics {} +` because it inspects `.gitignore` files and performs glob matching: in my tests, this branch ran `nil diagnostics` in `nixpkgs` in 6.75 seconds, compared to 6.35 seconds for the `find`-based solution.