### PR TITLE
Cargo.toml: Rename from `default_features` to `default-features`

### DIFF
--- a/crates/nil/Cargo.toml
+++ b/crates/nil/Cargo.toml
@@ -27,7 +27,7 @@ tracing = { version = "0.1.36", features = ["release_max_level_debug"] }
 
 [dependencies.tracing-subscriber]
 version = "0.3.15"
-default_features = false
+default-features = false
 features = [
     "env-filter",
     "fmt",


### PR DESCRIPTION
> `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition