### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/crates/ide/src/ty/known.rs
+++ b/crates/ide/src/ty/known.rs
@@ -85,7 +85,7 @@ static GENERIC_INPUT_DECL: Lazy<Ty> = Lazy::new(|| {
     )
 });
 
-/// <https://nixos.wiki/wiki/Flakes>
+/// <https://wiki.nixos.org/wiki/Flakes>
 pub fn flake(inputs: &[(&str, Ty)]) -> Ty {
     let inputs_decl_ty = Ty::Attrset(Attrset::from_internal(
         inputs.iter().map(|(name, ty)| {


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️