### PR TITLE
Add `remove_unused_binding` assist

### DIFF
--- a/crates/ide/src/ide/assists/mod.rs
+++ b/crates/ide/src/ide/assists/mod.rs
@@ -19,6 +19,7 @@ mod flatten_attrset;
 mod pack_bindings;
 mod remove_empty_inherit;
 mod remove_empty_let_in;
+mod remove_unused_binding;
 mod rewrite_string;
 
 use crate::{DefDatabase, FileRange, TextEdit, WorkspaceEdit};
@@ -49,6 +50,7 @@ pub(crate) fn assists(db: &dyn DefDatabase, frange: FileRange) -> Vec<Assist> {
         pack_bindings::pack_bindings,
         remove_empty_inherit::remove_empty_inherit,
         remove_empty_let_in::remove_empty_let_in,
+        remove_unused_binding::remove_unused_binding,
         rewrite_string::quote_attr,
         rewrite_string::rewrite_indented_to_string,
         rewrite_string::rewrite_string_to_indented,

--- a/crates/ide/src/ide/assists/remove_unused_binding.rs
+++ b/crates/ide/src/ide/assists/remove_unused_binding.rs
@@ -1,0 +1,304 @@
+//! Remove an unused pattern binding.
+//!
+//! ```nix
+//! { foo, bar }:{ foo = 1; }
+//! ```
+//! =>
+//! ```nix
+//! { foo }:{ foo = 1; }
+//! ```
+//!
+//! Or, remove an unused let binding.
+//!
+//! ```nix
+//! let
+//! foo.bar = 1;
+//! foo.baz = 2;
+//! in {}
+//! ```
+//! =>
+//! ```nix
+//! let
+//! in {}
+//! ```
+use super::{AssistKind, AssistsCtx};
+use crate::def::AstPtr;
+use crate::DiagnosticKind::UnusedBinding;
+use crate::TextEdit;
+use syntax::ast::AstNode;
+use syntax::rowan::SyntaxToken;
+use syntax::{ast, NixLanguage, SyntaxKind, SyntaxNode, TextRange};
+
+pub(super) fn remove_unused_binding(ctx: &mut AssistsCtx<'_>) -> Option<()> {
+    let cursor_attr = ctx.covering_node::<ast::Attr>()?;
+    let syntax = cursor_attr.syntax();
+    let range = syntax.text_range();
+
+    let file = ctx.frange.file_id;
+    let check = ctx.db.liveness_check(file);
+    let diags = check.as_ref().to_diagnostics(ctx.db, file);
+
+    let no_relevant_diags = diags
+        .filter(|d| d.kind == UnusedBinding && d.range.intersect(range).is_some())
+        .count()
+        == 0;
+
+    if no_relevant_diags {
+        return None;
+    }
+
+    let edits = delete_let_binding(ctx).or_else(|| delete_pattern_binding(syntax))?;
+    ctx.add(
+        "remove_unused_binding",
+        "Remove unused binding",
+        AssistKind::QuickFix,
+        edits,
+    );
+
+    Some(())
+}
+
+fn delete_let_binding(ctx: &mut AssistsCtx) -> Option<Vec<TextEdit>> {
+    // Only match Attr in `attr.path = value;`.
+    let cursor_attr = ctx.covering_node::<ast::Attr>()?;
+
+    let file = ctx.frange.file_id;
+    let src = ctx.db.file_content(file);
+    let source_map = ctx.db.source_map(file);
+    let name = source_map.name_for_node(AstPtr::new(cursor_attr.syntax()))?;
+
+    // Collect all bindings of this Attr.
+    let mut bindings = String::new();
+    let mut edits = Vec::new();
+    for ptr in source_map.nodes_for_name(name) {
+        let attr = ast::Attr::cast(ptr.to_node(ctx.ast.syntax()))?;
+        let path = ast::Attrpath::cast(attr.syntax().parent()?)?;
+        let path_value = ast::AttrpathValue::cast(path.syntax().parent()?)?;
+
+        let mut path_attr = path.attrs();
+
+        let binding_range = path_attr.next()?.syntax().text_range();
+
+        // Collect comments and whitespaces before each binding.
+        let trivia_start =
+            std::iter::successors(path_value.syntax().first_token(), |tok| tok.prev_token())
+                .skip(1)
+                .take_while(|tok| tok.kind().is_trivia())
+                .last()
+                .map_or_else(
+                    || path_value.syntax().text_range().start(),
+                    |tok| tok.text_range().start(),
+                );
+        let trivia_range = TextRange::new(trivia_start, path_value.syntax().text_range().start());
+
+        bindings += &src[trivia_range];
+        bindings += &src[binding_range];
+
+        // Delete the binding.
+        edits.push(TextEdit {
+            delete: path_value.syntax().text_range().cover_offset(trivia_start),
+            insert: Default::default(),
+        });
+    }
+
+    Some(edits)
+}
+
+fn delete_pattern_binding(syntax: &SyntaxNode) -> Option<Vec<TextEdit>> {
+    let mut delete_range = syntax.text_range();
+    let mut cur_token = syntax.last_token()?;
+
+    // Determine if this is the last pattern in the list
+    cur_token = skip_trivia(
+        std::iter::successors(syntax.last_token(), |tok| tok.next_token()).skip(1),
+        cur_token,
+    );
+    cur_token = cur_token.next_token()?;
+    let is_last = cur_token.kind() != SyntaxKind::COMMA;
+
+    if is_last {
+        // If the pattern is last in list, then go back and remove the preceding whitespace and comma
+        cur_token = skip_trivia(
+            std::iter::successors(syntax.last_token(), |tok| tok.prev_token()).skip(1),
+            cur_token,
+        );
+        cur_token = cur_token.prev_token()?;
+        if cur_token.kind() == SyntaxKind::COMMA {
+            cur_token = skip_trivia(
+                std::iter::successors(cur_token.prev_token(), |tok| tok.prev_token()),
+                cur_token,
+            );
+            delete_range = delete_range.cover(cur_token.text_range());
+        }
+    } else {
+        // If the pattern in not last in list, then continue to delete the following whitespace and comma
+        cur_token = skip_trivia(
+            std::iter::successors(cur_token.next_token(), |tok| tok.next_token()),
+            cur_token,
+        );
+        delete_range = delete_range.cover(cur_token.text_range());
+    }
+
+    Some(vec![TextEdit {
+        delete: delete_range,
+        insert: Default::default(),
+    }])
+}
+
+fn skip_trivia<I>(successors: I, default: SyntaxToken<NixLanguage>) -> SyntaxToken<NixLanguage>
+where
+    I: Iterator<Item = SyntaxToken<NixLanguage>>,
+{
+    successors
+        .take_while(|tok| tok.kind().is_trivia())
+        .last()
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use expect_test::expect;
+
+    define_check_assist!(super::remove_unused_binding);
+
+    #[test]
+    fn in_use_pattern_binding() {
+        check_no("{ $0stdenv }: stdenv.mkDerivation { } ");
+    }
+
+    #[test]
+    fn in_use_let_binding() {
+        check_no(
+            "
+let
+  $0foo.bar = 1;
+  $1foo.baz = 2;
+in foo
+",
+        );
+    }
+
+    #[test]
+    fn unused_pattern_binding() {
+        // First
+        check(
+            "{ $0hello , stdenv }: stdenv.mkDerivation { }",
+            expect![[r#"{ stdenv }: stdenv.mkDerivation { }"#]],
+        );
+
+        // With trivia
+        check(
+            "{ $0hello  /* trivia */, stdenv }: stdenv.mkDerivation { } ",
+            expect![[r#"{ stdenv }: stdenv.mkDerivation { }"#]],
+        );
+
+        // Last
+        check(
+            "{ stdenv , $0hello }: stdenv.mkDerivation { }",
+            expect![[r#"{ stdenv }: stdenv.mkDerivation { }"#]],
+        );
+
+        // Single
+        check(
+            " { $0hello }: stdenv.mkDerivation { } ",
+            expect![[r#" {  }: stdenv.mkDerivation { }"#]],
+        );
+    }
+
+    #[test]
+    fn unused_let_binding() {
+        // Flat
+        check(
+            "
+let
+  $0foo.bar = 1;
+  foo.baz = 2;
+in
+",
+            expect![[r#"
+let
+in
+"#]],
+        );
+
+        // With trivia
+        check(
+            "
+let
+  /* before */
+  $0foo.bar = 1;
+  /* middle */
+  foo.baz = 2;
+  /* after */
+in
+",
+            expect![[r#"
+let
+  /* after */
+in
+"#]],
+        );
+
+        // Nested
+        check(
+            "
+let
+  $0foo = {
+    bar = 1;
+    baz = 2;
+  };
+in
+",
+            expect![[r#"
+let
+in
+"#]],
+        );
+
+        // Flat & nested
+        check(
+            "
+let
+  $0foo = {
+    bar = 1;
+  };
+  foo.baz = 2;
+in
+",
+            expect![[r#"
+let
+in
+"#]],
+        );
+
+        // Used with unused
+        check(
+            "
+let
+  $0foo = {
+    bar = 1;
+  };
+  bar = 2;
+in bar
+",
+            expect![[r#"
+let
+  bar = 2;
+in bar
+"#]],
+        );
+
+        // lambda
+        check(
+            "
+let
+  $0x = a: { b }: c@{}: 0;
+in
+",
+            expect![[r#"
+let
+in
+"#]],
+        );
+    }
+}

--- a/docs/code_actions.md
+++ b/docs/code_actions.md
@@ -116,6 +116,32 @@ let in { foo = "bar"; }
 { foo = "bar"; }
 ```
 
+### `remove_unused_binding`
+
+Remove an unused pattern binding.
+
+```nix
+{ foo, bar }:{ foo = 1; }
+```
+=>
+```nix
+{ foo }:{ foo = 1; }
+```
+
+Or, remove an unused let binding.
+
+```nix
+let
+  foo.bar = 1;
+  foo.baz = 2;
+in {}
+```
+=>
+```nix
+let
+in {}
+```
+
 ### `rewrite_string_to_indented` and `rewrite_indented_to_string`
 
 Rewrite between double quoted strings and indented strings


### PR DESCRIPTION
Hi, 

I've had a go at implementing an assist to remove bindings for the `UnusedBinding` liveness check described on https://github.com/oxalica/nil/issues/39. If you have time to take a look that would be great, thanks.

The changes include adding a `remove_unused_binding` function which does the following steps

 1. Retrieves the diagnostics at the cursor and if `UnusedBinding` is not present then return
 2. Assume the cursor is at a let binding and attempt to delete it
     * I started from the `pack_bindings` implementation and removed the inner bindings logic to get the TextRange to delete.
 3. If the previous fails, assume the cursor is at a pattern binding and attempt to delete it
     * the code checks to see if there is a comma after the pattern name
         * If so, then it is deleted along with the trivia after
         * If not, the preceding comma and trivia is deleted
 4. If both let and pattern binding cases fail then return without any edits. (I have assumed that there are only these two cases)

I have added some tests and updated the code_action.md document also.