### PR TITLE
Split out devShells dependenties to dev/flake.nix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,11 +21,11 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare devShell
-        run: nix develop --command true
+        run: nix develop ./dev --command true
       - name: Install NPM packages
-        run: nix develop --command bash -c 'cd editors/coc-nil && npm ci'
-      - name: Run pre-commit
-        run: nix develop --command pre-commit
+        run: nix develop ./dev --command bash -c 'cd editors/coc-nil && npm ci'
+      - name: Run pre-push
+        run: nix develop ./dev --command bash ./dev/pre-push.sh
 
   test:
     name: Test
@@ -49,12 +49,12 @@ jobs:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
           nix_path: nixpkgs=channel:nixpkgs-unstable
       - name: Build
-        run: nix develop .#full --command cargo build --workspace --all-targets
+        run: nix develop ./dev#full --command cargo build --workspace --all-targets
       - name: Test
-        run: nix develop .#full --command cargo test --workspace --all-targets
+        run: nix develop ./dev#full --command cargo test --workspace --all-targets
       # Waiting for https://github.com/bheisler/criterion.rs/pull/703
       - name: Test with ignored
-        run: nix develop .#full --command cargo test --workspace --all-targets -- --ignored
+        run: nix develop ./dev#full --command cargo test --workspace --all-targets -- --ignored
 
   nix-flake:
     name: Flake package

--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1749619289,
+        "narHash": "sha256-qX6gXVjaCXXbcn6A9eSLUf8Fm07MgPGe5ir3++y2O1Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f72be405a10668b8b00937b452f2145244103ebc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1749695868,
+        "narHash": "sha256-debjTLOyqqsYOUuUGQsAHskFXH5+Kx2t3dOo/FCoNRA=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "55f914d5228b5c8120e9e0f9698ed5b7214d09cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -1,0 +1,110 @@
+{
+  description = "Development Environment for nil";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      rust-overlay,
+    }:
+    let
+      inherit (nixpkgs) lib;
+      eachSystem = lib.genAttrs lib.systems.flakeExposed;
+
+      # For rustfmt and fuzz.
+      nightlyVersion = "2025-06-01";
+    in
+    {
+      devShells = eachSystem (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          rustPkgs = rust-overlay.packages.${system};
+
+        in
+        rec {
+          without-rust = pkgs.mkShell {
+            nativeBuildInputs =
+              with pkgs;
+              [
+                # Override the stable rustfmt.
+                rustPkgs."rust-nightly_${nightlyVersion}".availableComponents.rustfmt
+
+                # Don't include `nix` by default. If would override user's (newer
+                # or patched) one, cause damage or misbehavior due to version
+                # mismatch.
+                # If you do want a locked one, use `devShells.full` below.
+
+                fd # Used by pre-push
+                nodejs
+                watchman # Required by coc.nvim for file watching.
+
+                jq
+                nixfmt-rfc-style
+                (import ./nvim-lsp.nix { inherit pkgs; })
+                (import ./vim-coc.nix { inherit pkgs; })
+                (import ./vim-lsp.nix { inherit pkgs; })
+              ]
+              ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform vscodium) [
+                (import ./vscodium.nix { inherit pkgs; })
+              ]
+              ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform gdb) [
+                gdb
+              ];
+
+            RUST_BACKTRACE = "short";
+            NIXPKGS = nixpkgs;
+
+            # bash
+            shellHook = ''
+              export NIL_PATH="$(cargo metadata --format-version=1 | jq -r .target_directory)/debug/nil"
+              export COC_NIL_PATH="$(realpath ./editors/coc-nil)"
+            '';
+          };
+
+          default = without-rust.overrideAttrs (old: {
+            nativeBuildInputs = old.nativeBuildInputs ++ [
+              # Follows nixpkgs's version of rustc.
+              (
+                let
+                  vers = lib.splitVersion pkgs.rustc.version;
+                in
+                rustPkgs."rust_${lib.elemAt vers 0}_${lib.elemAt vers 1}_${lib.elemAt vers 2}".override {
+                  extensions = [ "rust-src" ];
+                }
+              )
+            ];
+          });
+
+          # See comments above.
+          full = default.overrideAttrs (old: {
+            nativeBuildInputs = old.nativeBuildInputs ++ [
+              (pkgs.nixVersions.latest or pkgs.nixVersions.unstable).out
+            ];
+          });
+
+          fuzz = pkgs.mkShell {
+            packages = with pkgs; [
+              rustPkgs."rust-nightly_${nightlyVersion}"
+              cargo-fuzz
+              llvmPackages_14.llvm
+              jq
+              gnugrep
+            ];
+            RUST_BACKTRACE = "short";
+
+            # bash
+            shellHook = ''
+              export CARGO_TARGET_DIR=~/.cache/targets-syntax
+            '';
+          };
+        }
+      );
+    };
+}

--- a/dev/pre-push.sh
+++ b/dev/pre-push.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -eu
+# Requires: [ git nixfmt-rfc-style fd ], rust toolchain, npm toolchain
+
+die() { echo "$*" >&2; exit 1; }
+
+if git_dir="$(git rev-parse --show-toplevel)"; then
+  cd "$git_dir"
+fi
+cargo fmt --all --check \
+  || die 'cargo fmt failed'
+fd -e nix --exclude=crates/syntax/test_data --exec-batch nixfmt --check \
+  || die 'nixfmt failed'
+cargo clippy --workspace --all-targets -- -Dwarnings \
+  || die 'clippy failed'
+
+cd editors/coc-nil && npm run lint

--- a/flake.lock
+++ b/flake.lock
@@ -1,34 +1,16 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1749619289,
         "narHash": "sha256-qX6gXVjaCXXbcn6A9eSLUf8Fm07MgPGe5ir3++y2O1Q=",
-        "owner": "nixos",
+        "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "f72be405a10668b8b00937b452f2145244103ebc",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -36,44 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1749695868,
-        "narHash": "sha256-debjTLOyqqsYOUuUGQsAHskFXH5+Kx2t3dOo/FCoNRA=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "55f914d5228b5c8120e9e0f9698ed5b7214d09cd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,26 +1,22 @@
+# Note: This flake contains only main packages.
+# For development environment, see `./dev/flake.nix`.
 rec {
   description = "Language Server for Nix Expression Language";
 
   inputs = {
-    flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    rust-overlay.url = "github:oxalica/rust-overlay";
-    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   };
 
   outputs =
     {
       self,
-      flake-utils,
       nixpkgs,
-      rust-overlay,
     }:
     let
       inherit (builtins) substring;
       inherit (nixpkgs) lib;
 
-      # For rustfmt and fuzz.
-      nightlyVersion = "2025-06-01";
+      eachSystem = lib.genAttrs lib.systems.flakeExposed;
 
       mtime = self.lastModifiedDate;
       date = "${substring 0 4 mtime}-${substring 4 2 mtime}-${substring 6 2 mtime}";
@@ -76,125 +72,19 @@ rec {
           '';
 
     in
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-        rustPkgs = rust-overlay.packages.${system};
-
-        pre-commit = pkgs.writeShellScriptBin "pre-commit" ''
-          set -eu
-          export PATH="$PATH''${PATH:+:}"${
-            lib.escapeShellArg (
-              lib.makeBinPath [
-                pkgs.nixfmt-rfc-style
-                pkgs.fd
-                pkgs.findutils
-              ]
-            )
-          }
-
-          die() { echo "$*" >&2; exit 1; }
-
-          if git_dir="$(git rev-parse --show-toplevel)"; then
-            cd "$git_dir"
-          fi
-          cargo fmt --all --check \
-            || die 'cargo fmt failed'
-          fd -e nix --exclude=crates/syntax/test_data | xargs nixfmt --check \
-            || die 'nixfmt failed'
-          cargo clippy --workspace --all-targets -- -Dwarnings \
-            || die 'clippy failed'
-
-          cd editors/coc-nil && npm run lint
-        '';
-
-      in
-      rec {
-        packages = rec {
+    {
+      packages = eachSystem (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        rec {
           default = nil;
           nil = pkgs.callPackage mkNil { };
           coc-nil = pkgs.callPackage mkCocNil { };
-        };
+        }
+      );
 
-        devShells.without-rust = pkgs.mkShell {
-          nativeBuildInputs =
-            with pkgs;
-            [
-              # Override the stable rustfmt.
-              rustPkgs."rust-nightly_${nightlyVersion}".availableComponents.rustfmt
-
-              # Don't include `nix` by default. If would override user's (newer
-              # or patched) one, cause damage or misbehavior due to version
-              # mismatch.
-              # If you do want a locked one, use `devShells.full` below.
-
-              nodejs
-              watchman # Required by coc.nvim for file watching.
-
-              jq
-              pre-commit
-              nixfmt-rfc-style
-              (import ./dev/nvim-lsp.nix { inherit pkgs; })
-              (import ./dev/vim-coc.nix { inherit pkgs; })
-              (import ./dev/vim-lsp.nix { inherit pkgs; })
-            ]
-            ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform vscodium) [
-              (import ./dev/vscodium.nix { inherit pkgs; })
-            ]
-            ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform gdb) [
-              gdb
-            ];
-
-          RUST_BACKTRACE = "short";
-          NIXPKGS = nixpkgs;
-
-          # bash
-          shellHook = ''
-            export NIL_PATH="$(cargo metadata --format-version=1 | jq -r .target_directory)/debug/nil"
-            export COC_NIL_PATH="$(realpath ./editors/coc-nil)"
-          '';
-        };
-
-        devShells.default = devShells.without-rust.overrideAttrs (old: {
-          nativeBuildInputs = old.nativeBuildInputs ++ [
-            # Follows nixpkgs's version of rustc.
-            (
-              let
-                vers = lib.splitVersion pkgs.rustc.version;
-              in
-              rustPkgs."rust_${lib.elemAt vers 0}_${lib.elemAt vers 1}_${lib.elemAt vers 2}".override {
-                extensions = [ "rust-src" ];
-              }
-            )
-          ];
-        });
-
-        # See comments above.
-        devShells.full = devShells.default.overrideAttrs (old: {
-          nativeBuildInputs = old.nativeBuildInputs ++ [
-            (pkgs.nixVersions.latest or pkgs.nixVersions.unstable).out
-          ];
-        });
-
-        devShells.fuzz = pkgs.mkShell {
-          packages = with pkgs; [
-            rustPkgs."rust-nightly_${nightlyVersion}"
-            cargo-fuzz
-            llvmPackages_14.llvm
-            jq
-            gnugrep
-          ];
-          RUST_BACKTRACE = "short";
-
-          # bash
-          shellHook = ''
-            export CARGO_TARGET_DIR=~/.cache/targets-syntax
-          '';
-        };
-      }
-    )
-    // {
       overlays = {
         default = lib.composeExtensions self.overlays.nil self.overlays.coc-nil;
         nil = final: prev: {


### PR DESCRIPTION
This removes dev-dependencies from main `flake.nix`, so users of the main flake does not need to pull them in.