### PR TITLE
Feat: Inlay hints on the end of let/attrset bindings

### DIFF
--- a/crates/ide/src/ide/inlay_hints.rs
+++ b/crates/ide/src/ide/inlay_hints.rs
@@ -56,14 +56,14 @@ pub(crate) fn inlay_hints(
         if tok.kind() == SyntaxKind::SEMICOLON {
             let attr_path_value = tok.parent()?;
 
-            let spaning_lines = {
+            let spanning_lines = {
                 let mut acc = 1_usize; // we count from 1
                 attr_path_value
                     .text()
                     .for_each_chunk(|s| acc += s.matches('\n').count());
                 NonZero::new(acc).expect("must have positive amount of lines")
             };
-            if spaning_lines < threshold {
+            if spanning_lines < threshold {
                 return None;
             }
 

--- a/crates/ide/src/ide/inlay_hints.rs
+++ b/crates/ide/src/ide/inlay_hints.rs
@@ -30,13 +30,13 @@ pub(crate) fn inlay_hints(
 
     let hint_kind = |tok: &SyntaxToken| -> Option<InlayHintKind> {
         if tok.kind() == SyntaxKind::SEMICOLON {
-            let attribute_node = tok
+            let mut attribute_node = tok
                 .parent()?
                 .first_child_by_kind(&|u: SyntaxKind| u == SyntaxKind::ATTR_PATH)?
                 .children()
                 .filter(|node| !node.kind().is_trivia());
 
-            let attr_name = attribute_node.map(|node| node.to_string()).join(".");
+            let attr_name = attribute_node.join(".");
             Some(InlayHintKind::AttrsetAttribute(attr_name))
         } else {
             None

--- a/crates/ide/src/ide/inlay_hints.rs
+++ b/crates/ide/src/ide/inlay_hints.rs
@@ -40,6 +40,10 @@ pub(crate) fn inlay_hints(
     range: Option<TextRange>,
     config: InlayHintsConfig,
 ) -> Vec<InlayHintResult> {
+    let Some(threshold) = config.binding_end_hints_min_lines else {
+        return vec![];
+    };
+
     let root_node = db.parse(file).syntax_node();
 
     let (first_tok, end_pos) = match range {
@@ -50,9 +54,6 @@ pub(crate) fn inlay_hints(
         ),
     };
 
-    let binding_end_hints_min_lines = config
-        .binding_end_hints_min_lines
-        .unwrap_or(NonZero::new(25).expect("25 is nonzero"));
 
     let hint_kind = |tok: &SyntaxToken| -> Option<InlayHintKind> {
         if tok.kind() == SyntaxKind::SEMICOLON {
@@ -76,7 +77,7 @@ pub(crate) fn inlay_hints(
                 NonZero::new(count).expect("must have positive amount of lines")
             };
 
-            if spaning_lines < binding_end_hints_min_lines {
+            if spaning_lines < threshold {
                 return None;
             }
 

--- a/crates/ide/src/ide/inlay_hints.rs
+++ b/crates/ide/src/ide/inlay_hints.rs
@@ -1,0 +1,91 @@
+use itertools::Itertools;
+use syntax::{ast, match_ast, SyntaxKind, SyntaxToken, TextRange};
+
+use crate::{DefDatabase, FileId};
+
+#[derive(Debug, Clone)]
+pub enum InlayHintKind {
+    AttrsetAttribute(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct InlayHintResult {
+    pub range: TextRange,
+    pub kind: InlayHintKind,
+}
+
+pub(crate) fn inlay_hints(
+    db: &dyn DefDatabase,
+    file: FileId,
+    range: Option<TextRange>,
+) -> Vec<InlayHintResult> {
+    let root_node = db.parse(file).syntax_node();
+
+    let (first_tok, end_pos) = match range {
+        None => (root_node.first_token(), u32::MAX.into()),
+        Some(range) => (
+            root_node.token_at_offset(range.start()).right_biased(),
+            range.end(),
+        ),
+    };
+
+    // TODO:
+    // What is the best way to match ast?
+    // It would be nice to match on the shape `{ ... = <expr> ; }`
+    let hint_kind = |tok: &SyntaxToken| -> Option<InlayHintKind> {
+        let prev_token = {
+            let mut iter = std::iter::successors(Some(tok.clone()), |tok| tok.prev_token());
+            iter.next();
+            iter.find_or_first(|tok| !tok.kind().is_trivia())
+        };
+        let next_token = {
+            let mut iter = std::iter::successors(Some(tok.clone()), |tok| tok.next_token());
+            iter.next();
+            iter.find_or_first(|tok| !tok.kind().is_trivia())
+        };
+
+        match (prev_token, next_token) {
+            (Some(prev), Some(next))
+                if prev.kind() == SyntaxKind::EQ && next.kind() == SyntaxKind::SEMICOLON =>
+            {
+                // TODO: inlay hint label
+                Some(InlayHintKind::AttrsetAttribute("text".into()))
+            }
+            _ => None,
+        }
+    };
+
+    std::iter::successors(first_tok, |tok| tok.next_token())
+        .take_while(|tok| tok.text_range().start() < end_pos)
+        .filter(|tok| !tok.kind().is_trivia())
+        .filter_map(|tok| {
+            Some(InlayHintResult {
+                range: tok.text_range(),
+                kind: hint_kind(&tok)?,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::TestDB;
+    use crate::{DefDatabase, FilePos};
+    use expect_test::{expect, Expect};
+
+    #[track_caller]
+    fn check(fixture: &str, expect: Expect) {
+        let (db, f) = TestDB::from_fixture(fixture).unwrap();
+        let FilePos { file_id, .. } = f[0];
+        assert_eq!(db.parse(file_id).errors(), &[]);
+
+        let hints = super::inlay_hints(&db, file_id, None);
+        eprintln!("{:?}", hints);
+        expect.assert_eq("unimplemented");
+    }
+
+    #[test]
+    fn hint() {
+        check("$0{ foo = true; }", expect!["fail"]);
+    }
+}

--- a/crates/ide/src/ide/inlay_hints.rs
+++ b/crates/ide/src/ide/inlay_hints.rs
@@ -1,9 +1,6 @@
-use itertools::Itertools;
-use syntax::ast::{self, AstNode};
-use syntax::{match_ast, NixLanguage, SyntaxKind, SyntaxToken, TextRange};
-
-use crate::ide::expand_selection::expand_selection;
 use crate::{DefDatabase, FileId};
+use itertools::Itertools;
+use syntax::{SyntaxKind, SyntaxToken, TextRange};
 
 #[derive(Debug, Clone)]
 pub enum InlayHintKind {

--- a/crates/ide/src/ide/inlay_hints.rs
+++ b/crates/ide/src/ide/inlay_hints.rs
@@ -68,8 +68,7 @@ pub(crate) fn inlay_hints(
             }
 
             let is_rec_attr = ast::AttrSet::cast(attr_path_value.parent()?)
-                .map(|attr| attr.rec_token())
-                .flatten()
+                .and_then(|attr| attr.rec_token())
                 .is_some();
             let is_let = ast::LetIn::cast(attr_path_value.parent()?).is_some();
 
@@ -134,7 +133,7 @@ mod tests {
             InlayHintsConfig {
                 binding_end_hints_min_lines: Some(NonZero::new(1).expect("1 is nonzero")),
             },
-        )
+        );
     }
 
     #[track_caller]
@@ -145,7 +144,7 @@ mod tests {
             InlayHintsConfig {
                 binding_end_hints_min_lines: None,
             },
-        )
+        );
     }
 
     #[track_caller]
@@ -156,7 +155,7 @@ mod tests {
             InlayHintsConfig {
                 binding_end_hints_min_lines: Some(NonZero::new(5).expect("5 is nonzero")),
             },
-        )
+        );
     }
 
     #[test]

--- a/crates/ide/src/ide/inlay_hints.rs
+++ b/crates/ide/src/ide/inlay_hints.rs
@@ -31,11 +31,10 @@ pub(crate) fn inlay_hints(
         ),
     };
 
+    // TODO: detect trivial when we can not show the hint
     let hint_kind = |tok: &SyntaxToken| -> Option<InlayHintKind> {
         if tok.kind() == SyntaxKind::SEMICOLON {
             let attribute_node = tok
-                // Grab the attrset
-                .prev_sibling_or_token()?
                 .parent()?
                 // Grab the attrpath part, without space
                 .first_child_by_kind(&|u: SyntaxKind| u == SyntaxKind::ATTR_PATH)?

--- a/crates/ide/src/ide/mod.rs
+++ b/crates/ide/src/ide/mod.rs
@@ -6,6 +6,7 @@ mod file_references;
 mod goto_definition;
 mod highlight_related;
 mod hover;
+mod inlay_hints;
 mod links;
 mod references;
 mod rename;
@@ -30,6 +31,7 @@ pub use completion::{CompletionItem, CompletionItemKind};
 pub use goto_definition::GotoDefinitionResult;
 pub use highlight_related::HlRelated;
 pub use hover::HoverResult;
+pub use inlay_hints::{InlayHintKind, InlayHintResult};
 pub use links::{Link, LinkTarget};
 pub use rename::RenameResult;
 pub use symbol_hierarchy::SymbolTree;
@@ -206,6 +208,14 @@ impl Analysis {
 
     pub fn highlight_related(&self, fpos: FilePos) -> Cancellable<Vec<HlRelated>> {
         self.with_db(|db| highlight_related::highlight_related(db, fpos).unwrap_or_default())
+    }
+
+    pub fn inlay_hints(
+        &self,
+        file: FileId,
+        range: Option<TextRange>,
+    ) -> Cancellable<Vec<InlayHintResult>> {
+        self.with_db(|db| inlay_hints::inlay_hints(db, file, range))
     }
 
     //// Custom extensions ////

--- a/crates/ide/src/ide/mod.rs
+++ b/crates/ide/src/ide/mod.rs
@@ -31,7 +31,7 @@ pub use completion::{CompletionItem, CompletionItemKind};
 pub use goto_definition::GotoDefinitionResult;
 pub use highlight_related::HlRelated;
 pub use hover::HoverResult;
-pub use inlay_hints::{InlayHintKind, InlayHintResult};
+pub use inlay_hints::{InlayHintKind, InlayHintResult, InlayHintsConfig};
 pub use links::{Link, LinkTarget};
 pub use rename::RenameResult;
 pub use symbol_hierarchy::SymbolTree;
@@ -214,8 +214,9 @@ impl Analysis {
         &self,
         file: FileId,
         range: Option<TextRange>,
+        config: InlayHintsConfig,
     ) -> Cancellable<Vec<InlayHintResult>> {
-        self.with_db(|db| inlay_hints::inlay_hints(db, file, range))
+        self.with_db(|db| inlay_hints::inlay_hints(db, file, range, config))
     }
 
     //// Custom extensions ////

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -13,7 +13,8 @@ mod tests;
 pub use self::ide::{
     Analysis, AnalysisHost, Assist, AssistKind, Cancelled, CompletionItem, CompletionItemKind,
     GotoDefinitionResult, HlAttrField, HlKeyword, HlOperator, HlPunct, HlRange, HlRelated, HlTag,
-    HoverResult, Link, LinkTarget, NavigationTarget, RenameResult, SymbolTree,
+    HoverResult, InlayHintKind, InlayHintResult, Link, LinkTarget, NavigationTarget, RenameResult,
+    SymbolTree,
 };
 pub use base::{
     Change, FileId, FilePos, FileRange, FileSet, FlakeGraph, FlakeInfo, InFile, SourceDatabase,

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -13,8 +13,8 @@ mod tests;
 pub use self::ide::{
     Analysis, AnalysisHost, Assist, AssistKind, Cancelled, CompletionItem, CompletionItemKind,
     GotoDefinitionResult, HlAttrField, HlKeyword, HlOperator, HlPunct, HlRange, HlRelated, HlTag,
-    HoverResult, InlayHintKind, InlayHintResult, Link, LinkTarget, NavigationTarget, RenameResult,
-    SymbolTree,
+    HoverResult, InlayHintKind, InlayHintResult, InlayHintsConfig, Link, LinkTarget,
+    NavigationTarget, RenameResult, SymbolTree,
 };
 pub use base::{
     Change, FileId, FilePos, FileRange, FileSet, FlakeGraph, FlakeInfo, InFile, SourceDatabase,

--- a/crates/nil/src/capabilities.rs
+++ b/crates/nil/src/capabilities.rs
@@ -1,10 +1,11 @@
 use crate::semantic_tokens::{SEMANTIC_TOKEN_MODIFIERS, SEMANTIC_TOKEN_TYPES};
 use lsp_types::{
     CodeActionProviderCapability, CompletionOptions, DocumentLinkOptions, HoverProviderCapability,
-    InitializeParams, OneOf, RenameOptions, SelectionRangeProviderCapability,
-    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
-    SemanticTokensServerCapabilities, ServerCapabilities, TextDocumentSyncCapability,
-    TextDocumentSyncKind, TextDocumentSyncOptions, WorkDoneProgressOptions,
+    InitializeParams, InlayHintServerCapabilities, OneOf, RenameOptions,
+    SelectionRangeProviderCapability, SemanticTokensFullOptions, SemanticTokensLegend,
+    SemanticTokensOptions, SemanticTokensServerCapabilities, ServerCapabilities,
+    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+    WorkDoneProgressOptions,
 };
 
 macro_rules! test {
@@ -92,6 +93,7 @@ pub(crate) fn negotiate_capabilities(
         }),
         code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
         document_highlight_provider: Some(OneOf::Left(true)),
+        inlay_hint_provider: Some(OneOf::Left(true)),
         ..Default::default()
     };
 

--- a/crates/nil/src/capabilities.rs
+++ b/crates/nil/src/capabilities.rs
@@ -1,11 +1,10 @@
 use crate::semantic_tokens::{SEMANTIC_TOKEN_MODIFIERS, SEMANTIC_TOKEN_TYPES};
 use lsp_types::{
     CodeActionProviderCapability, CompletionOptions, DocumentLinkOptions, HoverProviderCapability,
-    InitializeParams, InlayHintServerCapabilities, OneOf, RenameOptions,
-    SelectionRangeProviderCapability, SemanticTokensFullOptions, SemanticTokensLegend,
-    SemanticTokensOptions, SemanticTokensServerCapabilities, ServerCapabilities,
-    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
-    WorkDoneProgressOptions,
+    InitializeParams, OneOf, RenameOptions, SelectionRangeProviderCapability,
+    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
+    SemanticTokensServerCapabilities, ServerCapabilities, TextDocumentSyncCapability,
+    TextDocumentSyncKind, TextDocumentSyncOptions, WorkDoneProgressOptions,
 };
 
 macro_rules! test {

--- a/crates/nil/src/config.rs
+++ b/crates/nil/src/config.rs
@@ -1,6 +1,7 @@
 use anyhow::ensure;
 use lsp_types::Url;
 use std::collections::HashSet;
+use std::num::NonZero;
 use std::path::PathBuf;
 
 pub const CONFIG_KEY: &str = "nil";
@@ -72,6 +73,8 @@ pub struct Config {
     pub diagnostics_ignored: HashSet<String>,
     #[parse("/formatting/command", parse = Config::parse_optional_command)]
     pub formatting_command: Option<Vec<String>>,
+    #[parse("/diagnostics/bindingEndHintMinLines", parse = Config::parse_nonzero_usize)]
+    pub binding_end_hints_min_lines: Option<NonZero<usize>>,
     #[parse("/nix/binary", default = "nix".into())]
     pub nix_binary: PathBuf,
     #[parse("/nix/maxMemoryMB", default = Some(2048))]
@@ -99,6 +102,11 @@ impl Config {
     ) -> anyhow::Result<Option<Vec<String>>> {
         ensure!(v != Some(Vec::new()), "command must not be empty");
         Ok(v)
+    }
+
+    fn parse_nonzero_usize(&mut self, v: Option<usize>) -> anyhow::Result<Option<NonZero<usize>>> {
+        let nz = v.map(|raw_value| NonZero::new(raw_value).expect("value must be positive"));
+        Ok(nz)
     }
 
     pub fn nix_max_memory(&self) -> Option<u64> {

--- a/crates/nil/src/convert.rs
+++ b/crates/nil/src/convert.rs
@@ -391,13 +391,6 @@ pub(crate) fn from_document_link(
 pub(crate) fn to_inlay_hints(line_map: &LineMap, hints: Vec<InlayHintResult>) -> Vec<InlayHint> {
     hints
         .iter()
-        // Drop hints that are on the same line
-        .filter(|hint| {
-            let InlayHintResult { range, .. } = hint;
-            let (line1, _) = line_map.line_col_for_pos(range.start());
-            let (line2, _) = line_map.line_col_for_pos(range.end());
-            line1 != line2
-        })
         .map(|hint| {
             let InlayHintResult { range, kind } = hint;
 

--- a/crates/nil/src/convert.rs
+++ b/crates/nil/src/convert.rs
@@ -391,8 +391,16 @@ pub(crate) fn from_document_link(
 pub(crate) fn to_inlay_hints(line_map: &LineMap, hints: Vec<InlayHintResult>) -> Vec<InlayHint> {
     hints
         .iter()
+        // Drop hints that are on the same line
+        .filter(|hint| {
+            let InlayHintResult { range, .. } = hint;
+            let (line1, _) = line_map.line_col_for_pos(range.start());
+            let (line2, _) = line_map.line_col_for_pos(range.end());
+            line1 != line2
+        })
         .map(|hint| {
             let InlayHintResult { range, kind } = hint;
+
             match kind {
                 InlayHintKind::AttrsetAttribute(s) => InlayHint {
                     position: {

--- a/crates/nil/src/convert.rs
+++ b/crates/nil/src/convert.rs
@@ -396,7 +396,7 @@ pub(crate) fn to_inlay_hints(line_map: &LineMap, hints: Vec<InlayHintResult>) ->
             match kind {
                 InlayHintKind::AttrsetAttribute(s) => InlayHint {
                     position: {
-                        let (line, character) = line_map.line_col_for_pos(range.start());
+                        let (line, character) = line_map.line_col_for_pos(range.end());
                         Position { line, character }
                     },
                     label: InlayHintLabel::String(s.clone()),
@@ -404,7 +404,7 @@ pub(crate) fn to_inlay_hints(line_map: &LineMap, hints: Vec<InlayHintResult>) ->
                     text_edits: None,
                     tooltip: None,
                     padding_left: None,
-                    padding_right: None,
+                    padding_right: Some(true),
                     data: None,
                 },
             }

--- a/crates/nil/src/convert.rs
+++ b/crates/nil/src/convert.rs
@@ -2,8 +2,8 @@ use crate::{semantic_tokens, LineMap, Result, Vfs};
 use async_lsp::{ErrorCode, ResponseError};
 use ide::{
     Assist, AssistKind, CompletionItem, CompletionItemKind, Diagnostic, FileId, FilePos, FileRange,
-    HlRange, HlRelated, HoverResult, InlayHintKind, InlayHintResult, Link, LinkTarget, NameKind,
-    Severity, SymbolTree, TextEdit, WorkspaceEdit,
+    HlRange, HlRelated, HoverResult, InlayHintResult, Link, LinkTarget, NameKind, Severity,
+    SymbolTree, TextEdit, WorkspaceEdit,
 };
 use lsp_types::{
     self as lsp, CodeAction, CodeActionKind, CodeActionOrCommand, DiagnosticRelatedInformation,
@@ -401,20 +401,20 @@ pub(crate) fn to_inlay_hints(line_map: &LineMap, hints: Vec<InlayHintResult>) ->
         .map(|hint| {
             let InlayHintResult { range, kind } = hint;
 
-            match kind {
-                InlayHintKind::AttrsetAttribute(s) => InlayHint {
-                    position: {
-                        let (line, character) = line_map.line_col_for_pos(range.end());
-                        Position { line, character }
-                    },
-                    label: InlayHintLabel::String(format!("= {s}")),
-                    kind: None,
-                    text_edits: None,
-                    tooltip: None,
-                    padding_left: Some(true),
-                    padding_right: None,
-                    data: None,
+            let label = kind.to_string();
+
+            InlayHint {
+                position: {
+                    let (line, character) = line_map.line_col_for_pos(range.end());
+                    Position { line, character }
                 },
+                label: InlayHintLabel::String(label),
+                kind: None,
+                text_edits: None,
+                tooltip: None,
+                padding_left: Some(true),
+                padding_right: None,
+                data: None,
             }
         })
         .collect()

--- a/crates/nil/src/convert.rs
+++ b/crates/nil/src/convert.rs
@@ -399,12 +399,12 @@ pub(crate) fn to_inlay_hints(line_map: &LineMap, hints: Vec<InlayHintResult>) ->
                         let (line, character) = line_map.line_col_for_pos(range.end());
                         Position { line, character }
                     },
-                    label: InlayHintLabel::String(s.clone()),
+                    label: InlayHintLabel::String(format!("= {s}")),
                     kind: None,
                     text_edits: None,
                     tooltip: None,
-                    padding_left: None,
-                    padding_right: Some(true),
+                    padding_left: Some(true),
+                    padding_right: None,
                     data: None,
                 },
             }

--- a/crates/nil/src/handler.rs
+++ b/crates/nil/src/handler.rs
@@ -6,10 +6,11 @@ use lsp_types::{
     CodeActionParams, CodeActionResponse, CompletionParams, CompletionResponse,
     DocumentFormattingParams, DocumentHighlight, DocumentHighlightParams, DocumentLink,
     DocumentLinkParams, DocumentSymbolParams, DocumentSymbolResponse, GotoDefinitionParams,
-    GotoDefinitionResponse, Hover, HoverParams, Location, Position, PrepareRenameResponse, Range,
-    ReferenceParams, RenameParams, SelectionRange, SelectionRangeParams, SemanticTokens,
-    SemanticTokensParams, SemanticTokensRangeParams, SemanticTokensRangeResult,
-    SemanticTokensResult, TextDocumentPositionParams, TextEdit, Url, WorkspaceEdit,
+    GotoDefinitionResponse, Hover, HoverParams, InlayHint, InlayHintParams, Location, Position,
+    PrepareRenameResponse, Range, ReferenceParams, RenameParams, SelectionRange,
+    SelectionRangeParams, SemanticTokens, SemanticTokensParams, SemanticTokensRangeParams,
+    SemanticTokensRangeResult, SemanticTokensResult, TextDocumentPositionParams, TextEdit, Url,
+    WorkspaceEdit,
 };
 use nix_interop::DEFAULT_IMPORT_FILE;
 use std::process;
@@ -321,4 +322,21 @@ pub(crate) fn parent_module(
         .map(|file| convert::to_location(&vfs, FileRange::new(file, TextRange::default())))
         .collect();
     Ok(Some(GotoDefinitionResponse::Array(locs)))
+}
+
+pub(crate) fn inlay_hints(
+    snap: StateSnapshot,
+    params: InlayHintParams,
+) -> Result<Option<Vec<InlayHint>>> {
+    let (file, range, line_map) = {
+        let vfs = snap.vfs();
+        let (file, line_map) = convert::from_file(&vfs, &params.text_document)?;
+        let (_, range) = convert::from_range(&vfs, file, params.range)?;
+        (file, range, line_map)
+    };
+
+    let hint_result = snap.analysis.inlay_hints(file, Some(range))?;
+    let hints = convert::to_inlay_hints(&line_map, hint_result);
+
+    Ok(Some(hints))
 }

--- a/crates/nil/src/handler.rs
+++ b/crates/nil/src/handler.rs
@@ -1,7 +1,7 @@
 use crate::{convert, StateSnapshot};
 use anyhow::{ensure, Context, Result};
 use async_lsp::{ErrorCode, ResponseError};
-use ide::{FileRange, GotoDefinitionResult};
+use ide::{FileRange, GotoDefinitionResult, InlayHintsConfig};
 use lsp_types::{
     CodeActionParams, CodeActionResponse, CompletionParams, CompletionResponse,
     DocumentFormattingParams, DocumentHighlight, DocumentHighlightParams, DocumentLink,
@@ -335,7 +335,13 @@ pub(crate) fn inlay_hints(
         (file, range, line_map)
     };
 
-    let hint_result = snap.analysis.inlay_hints(file, Some(range))?;
+    let inlay_hint_config = InlayHintsConfig {
+        binding_end_hints_min_lines: snap.config.binding_end_hints_min_lines,
+    };
+
+    let hint_result = snap
+        .analysis
+        .inlay_hints(file, Some(range), inlay_hint_config)?;
     let hints = convert::to_inlay_hints(&line_map, hint_result);
 
     Ok(Some(hints))

--- a/crates/nil/src/server.rs
+++ b/crates/nil/src/server.rs
@@ -122,6 +122,7 @@ impl Server {
             .request_snap::<req::CodeActionRequest>(handler::code_action)
             .request_snap::<req::DocumentHighlightRequest>(handler::document_highlight)
             .request_snap::<lsp_ext::ParentModule>(handler::parent_module)
+            .request_snap::<req::InlayHintRequest>(handler::inlay_hints)
             //// Events ////
             .event(Self::on_set_flake_info)
             .event(Self::on_set_nixos_options)

--- a/docs/features.md
+++ b/docs/features.md
@@ -110,6 +110,9 @@ This incomplete list tracks noteble features currently implemented or planned.
 - [x] Multi-threaded.
   - [x] Request cancellation. `$/cancelRequest`
 
+- [x] Inlay Hints `textDocument/inlayHint`
+  - [x] Display attribute name when the definition is long
+
 [`coc.nvim`]: https://github.com/neoclide/coc.nvim
 [flake-ref]: https://nixos.org/manual/nix/unstable/command-ref/new-cli/nix3-flake.html#types
 


### PR DESCRIPTION
Attempt to implement #166.

I haven't figured out the best way to match on the ast.
It would be nice to match on the shape `{ attrName = <expr> ; }`, where we display `attrName` right after `<expr>` or the semicolon.

 
