### PR TITLE
Fix the infer of list object types

### DIFF
--- a/crates/ide/src/ty/infer.rs
+++ b/crates/ide/src/ty/infer.rs
@@ -503,6 +503,10 @@ impl InferCtx<'_> {
                             self.unify_var(dyn_ty_var, var);
                         }
                     }
+                    (Ty::List(a), super::Ty::List(b)) => {
+                        let el = self.import_external(b.as_ref().clone());
+                        self.unify_var(a, el);
+                    }
                     _ => {}
                 }
                 Ty::External(external)


### PR DESCRIPTION
The code simply did not have a match for the lists, so for example, for which configuration there were no suggestions.

```nix
settings = lib.mkOption {
  type = lib.types.listOf (lib.types.submodule {
    options = {
      logLevel = lib.mkOption {
        type = lib.types.enum ["debug" "info" "warn" "error"];
        default = "info";
      };
    };
  });
  default = {};
};
```

```nix
{
  settings = [ {
    <CURSOR FOR SUGGESTION>
  } ];
}
```

After this fix, logLevel is suggested.