### PR TITLE
fix error suggestion select if the object is enclosed in paren

### DIFF
--- a/crates/ide/src/ide/completion.rs
+++ b/crates/ide/src/ide/completion.rs
@@ -477,8 +477,8 @@ impl Context<'_> {
 
         let prefix = match_ast! {
             match (node.syntax().parent()?){
-                ast::HasAttr(n) => Prefix::SetExpr(n.set()?.syntax().clone()),
-                ast::Select(n) => Prefix::SetExpr(n.set()?.syntax().clone()),
+                ast::HasAttr(n) => Prefix::SetExpr(n.set()?.unwrap_all_paren().syntax().clone()),
+                ast::Select(n) => Prefix::SetExpr(n.set()?.unwrap_all_paren().syntax().clone()),
                 ast::AttrpathValue(n) => {
                     // We are typing the first word of a binding.
                     if prefix_attrs.peek().is_none() {

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -329,6 +329,14 @@ impl Expr {
             _ => false,
         }
     }
+
+    pub fn unwrap_all_paren(self) -> Expr {
+        let mut res = self;
+        while let Self::Paren(e) = res {
+            res = e.expr().unwrap();
+        }
+        res
+    }
 }
 
 asts! {


### PR DESCRIPTION
Reproduce
```
{lib, ...}: let
  fn = a: {
    b = 10;
  };
  u = (fn 10).<CURSOR FOR COMPLETION>;

  a = {
    x = 10;
  };
  b = (a).<CURSOR FOR COMPLETION>;
in {
}
```
there are no suggestions before the fix, after that there are suggestions

This is because there is no allocation in the crates/ide/src/def/lower.rs for the ast node Parent. 

I do not know how best to solve this, so this is just a suggestion, perhaps it would be better to add an allocation for Paren.