### PR TITLE
Fix inline bugs

### DIFF
--- a/crates/ide/src/ide/assists/inline.rs
+++ b/crates/ide/src/ide/assists/inline.rs
@@ -192,6 +192,10 @@ mod tests {
             "let $0foo = 1; bar = 2; in { inherit foo bar; }",
             expect!["let  bar = 2; in { inherit  bar; foo = 1; }"],
         );
+        check(
+            "let $0foo = 1; bar = 2; in let inherit foo bar; in null",
+            expect!["let  bar = 2; in let inherit  bar; foo = 1; in null"],
+        );
     }
 
     #[test]
@@ -203,6 +207,10 @@ mod tests {
         check(
             "let foo = 1; bar = 2; in { inherit $0foo bar; }",
             expect!["let foo = 1; bar = 2; in { inherit  bar; foo = 1; }"],
+        );
+        check(
+            "let foo = 1; bar = 2; in let inherit $0foo bar; in null",
+            expect!["let foo = 1; bar = 2; in let inherit  bar; foo = 1; in null"],
         );
     }
 

--- a/crates/ide/src/ide/assists/inline.rs
+++ b/crates/ide/src/ide/assists/inline.rs
@@ -144,4 +144,22 @@ mod tests {
             expect!["rec { foo = 1; bar = 1; baz = 1; }"],
         );
     }
+
+    #[test]
+    fn no_inherit() {
+        check_no(
+            r#"
+{
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }: {
+    inherit $0flake-utils;
+  };
+}
+        "#,
+        );
+        check_no("let $0foo = 1; in { inherit foo; }");
+    }
 }

--- a/crates/ide/src/ide/assists/inline.rs
+++ b/crates/ide/src/ide/assists/inline.rs
@@ -147,10 +147,7 @@ mod tests {
 
     #[test]
     fn let_in_ref() {
-        check(
-            r#"let a = "foo"; in $0a"#,
-            expect![r#"let a = "foo"; in "foo""#],
-        );
+        check("let a = 1; in $0a", expect!["let a = 1; in 1"]);
         check(
             "let a = x: x; in $0a 1",
             expect!["let a = x: x; in (x: x) 1"],
@@ -164,12 +161,13 @@ mod tests {
 
     #[test]
     fn no_let_in_multi() {
-        check_no(r#"let a.b = "foo"; a.c = "bar"; in $0a"#);
-        check_no(r#"let a.b$0 = "foo"; a.c = "bar"; in a"#);
+        check_no("let a.b = 1; a.c = 2; in $0a");
+        check_no("let a.b$0 = 1; a.c = 2; in a");
+        check_no("let $0a.b = 1; a.c = 2; in a");
     }
 
     #[test]
-    fn attr_ref() {
+    fn rec_attr_ref() {
         check(
             "rec { foo = 1; bar = $0foo; }",
             expect!["rec { foo = 1; bar = 1; }"],
@@ -177,7 +175,7 @@ mod tests {
     }
 
     #[test]
-    fn attr_def() {
+    fn rec_attr_def() {
         check(
             "rec { $0foo = 1; bar = foo; baz = foo; }",
             expect!["rec { foo = 1; bar = 1; baz = 1; }"],
@@ -186,7 +184,6 @@ mod tests {
 
     #[test]
     fn allow_inherit_usage_def() {
-        // inherit in usage from definition
         check(
             "let $0foo = 1; in { inherit foo; }",
             expect!["let  in { inherit ; foo = 1; }"],
@@ -199,7 +196,6 @@ mod tests {
 
     #[test]
     fn allow_inherit_usage_ref() {
-        // inherit in usage from definition
         check(
             "let foo = 1; in { inherit $0foo; }",
             expect!["let foo = 1; in { inherit ; foo = 1; }"],
@@ -211,9 +207,9 @@ mod tests {
     }
 
     #[test]
-    fn no_inherit_definition() {
-        check_no("with lib; let inherit (lib) $0foo; in foo");
-        check_no("with lib; let inherit (lib) foo; in $0foo");
+    fn no_allow_inherit_as_def() {
+        check_no("let inherit (lib) $0foo; in foo");
+        check_no("let inherit (lib) foo; in $0foo");
     }
 
     #[test]

--- a/crates/ide/src/ide/assists/inline.rs
+++ b/crates/ide/src/ide/assists/inline.rs
@@ -171,18 +171,40 @@ mod tests {
     }
 
     #[test]
-    fn no_inherit() {
-        check_no("{ outputs = { nixpkgs, ... }: { inherit $0nixpkgs; }; }");
+    fn allow_inherit_usage_def() {
+        // inherit in usage from definition
         check(
             "let $0foo = 1; in { inherit foo; }",
-            expect!["let  in { foo = 1; }"],
+            expect!["let  in { inherit ; foo = 1; }"],
         );
+        check(
+            "let $0foo = 1; bar = 2; in { inherit foo bar; }",
+            expect!["let  bar = 2; in { inherit  bar; foo = 1; }"],
+        );
+    }
+
+    #[test]
+    fn allow_inherit_usage_ref() {
+        // inherit in usage from definition
+        check(
+            "let foo = 1; in { inherit $0foo; }",
+            expect!["let foo = 1; in { inherit ; foo = 1; }"],
+        );
+        check(
+            "let foo = 1; bar = 2; in { inherit $0foo bar; }",
+            expect!["let foo = 1; bar = 2; in { inherit  bar; foo = 1; }"],
+        );
+    }
+
+    #[test]
+    fn no_inherit_definition() {
         check_no("with lib; let inherit (lib) $0foo; in foo");
         check_no("with lib; let inherit (lib) foo; in $0foo");
     }
 
     #[test]
     fn no_patfield() {
+        check_no("{ outputs = { nixpkgs, ... }: { inherit $0nixpkgs; }; }");
         check_no("{ outputs = { $0nixpkgs, ... }: { inherit nixpkgs; }; }");
         check_no("{ outputs = { $0nixpkgs, ... }: nixpkgs; }");
     }

--- a/crates/ide/src/ide/assists/inline.rs
+++ b/crates/ide/src/ide/assists/inline.rs
@@ -162,4 +162,21 @@ mod tests {
         );
         check_no("let $0foo = 1; in { inherit foo; }");
     }
+
+    #[test]
+    fn no_patfield() {
+        check_no(
+            r#"
+{
+  outputs = {
+    self,
+    nixpkgs,
+    $0flake-utils,
+  }: {
+    inherit flake-utils;
+  };
+}
+        "#,
+        );
+    }
 }

--- a/crates/ide/src/ide/assists/inline.rs
+++ b/crates/ide/src/ide/assists/inline.rs
@@ -69,7 +69,11 @@ pub(super) fn inline(ctx: &mut AssistsCtx<'_>) -> Option<()> {
                 _ => None,
             });
 
-            let is_letin = ast::LetIn::cast(path_value.syntax().parent()?).is_some();
+            let is_letin = path_value
+                .syntax()
+                .parent()
+                .and_then(ast::LetIn::cast)
+                .is_some();
             if is_letin {
                 rewrites.push(TextEdit {
                     delete: path_value.syntax().text_range(),

--- a/crates/ide/src/ide/assists/inline.rs
+++ b/crates/ide/src/ide/assists/inline.rs
@@ -161,36 +161,15 @@ mod tests {
 
     #[test]
     fn no_inherit() {
-        check_no(
-            r#"
-{
-  outputs = {
-    self,
-    nixpkgs,
-    flake-utils,
-  }: {
-    inherit $0flake-utils;
-  };
-}
-        "#,
-        );
-        check_no("let $0foo = 1; in { inherit foo; }");
+        check_no("{ outputs = { nixpkgs, ... }: { inherit $0nixpkgs; }; }");
+        check("let $0foo = 1; in { inherit foo; }", expect!["let  in { foo = 1; }"]);
+        check_no("with lib; let inherit (lib) $0foo; in foo");
+        check_no("with lib; let inherit (lib) foo; in $0foo");
     }
 
     #[test]
     fn no_patfield() {
-        check_no(
-            r#"
-{
-  outputs = {
-    self,
-    nixpkgs,
-    $0flake-utils,
-  }: {
-    inherit flake-utils;
-  };
-}
-        "#,
-        );
+        check_no("{ outputs = { $0nixpkgs, ... }: { inherit nixpkgs; }; }");
+        check_no("{ outputs = { $0nixpkgs, ... }: nixpkgs; }");
     }
 }


### PR DESCRIPTION
Hello,

I noticed multiple bugs in my previous PR, sorry about that.
This PR does multiple checks to make sure no incorrect assists are generated, namely:
- non recursive attrsets
- bindings that are used in its own definition
- pattern binds in lambda arguments
- inherit clauses with `from` expressions 

Inherit usages are now rewritten with the inherit node removed, and with an extra binding added.

I also fixed a part where I traverse the AST too loosely (`.ancestors()`) and would overshoot, publishing incorrect assists.

Do let me know if there are cases that I haven't covered! Inlining expressions are way more tricky than I thought it was.

Thank you for your time!