### PR TITLE
Use `--extra-experimental-features` to prevent overriding user's config

### DIFF
--- a/crates/nix-interop/src/flake_lock.rs
+++ b/crates/nix-interop/src/flake_lock.rs
@@ -213,7 +213,7 @@ pub async fn archive(nix_command: &Path, flake_url: &FlakeUrl) -> Result<()> {
         .args([
             "flake",
             "archive",
-            "--experimental-features",
+            "--extra-experimental-features",
             "nix-command flakes",
             "--json",
         ])

--- a/crates/nix-interop/src/flake_output.rs
+++ b/crates/nix-interop/src/flake_output.rs
@@ -23,7 +23,7 @@ pub async fn eval_flake_output(
         .args([
             "flake",
             "show",
-            "--experimental-features",
+            "--extra-experimental-features",
             "nix-command flakes",
             "--json",
         ])

--- a/crates/nix-interop/src/nixos_options.rs
+++ b/crates/nix-interop/src/nixos_options.rs
@@ -17,7 +17,7 @@ pub async fn eval_all_options(nix_command: &Path, nixpkgs_path: &Path) -> Result
         .kill_on_drop(true)
         .args([
             "eval",
-            "--experimental-features",
+            "--extra-experimental-features",
             "nix-command",
             "--read-only",
             "--impure",


### PR DESCRIPTION
Changed `--experimental-features` to `--extra-experimental-features` in `nix flake <show/archive>` and `nix eval` commands, to avoid errors when doing so would require more experimental features than just nix-command and flakes. I personally ran into this issue with `autoArchive` since my flake uses pipe operators.