### PR TITLE
Fix sourcehut link resolve

### DIFF
--- a/crates/ide/src/ide/links.rs
+++ b/crates/ide/src/ide/links.rs
@@ -130,7 +130,7 @@ fn try_resolve_link_uri(uri: &str) -> Option<Url> {
         let owner = iter.next()?;
         let repo = iter.next()?;
         // let rev = iter.next()?; // TODO
-        return Some(format!("https://sr.ht/{owner}/{repo}").parse().unwrap());
+        return Some(format!("https://git.sr.ht/{owner}/{repo}").parse().unwrap());
     }
 
     // For `anything+(file|path)://...`, chop it to `file://`.

--- a/crates/ide/src/ide/links.rs
+++ b/crates/ide/src/ide/links.rs
@@ -110,7 +110,7 @@ fn try_resolve_link_uri(uri: &str) -> Option<Url> {
         let owner = iter.next()?;
         let repo = iter.next()?;
         // let rev = iter.next()?; // TODO
-        return Some(format!("https://sr.ht/{owner}/{repo}").parse().unwrap());
+        return Some(format!("https://git.sr.ht/{owner}/{repo}").parse().unwrap());
     }
 
     // For `anything+(file|path)://...`, chop it to `file://`.


### PR DESCRIPTION
the sourcehut url in flake is [resolved in nix to a repository](https://nix.dev/manual/nix/2.34/command-ref/new-cli/nix3-flake#examples:~:text=SourceHut%20repositories) and not to [a project](https://man.sr.ht/hub.sr.ht/).

and assuming people don't use sourcehut for their mecurial repos ([given the unstable nature of hg hosting support on sourcehut](https://man.sr.ht/hg.sr.ht/#:~:text=work%20in%20progress)), it would be safe to resolve such flake url to [the git hosting site](https://man.sr.ht/git.sr.ht/)

see also https://github.com/rszyma/nil/pull/3