### PR TITLE
Fix tests for nix 2.35.1

### DIFF
--- a/crates/builtin/src/lib.rs
+++ b/crates/builtin/src/lib.rs
@@ -47,7 +47,9 @@ mod tests {
                     "\
 Return the names of the attributes in the set *set* in an
 alphabetically sorted list. For instance, `builtins.attrNames { y
-= 1; x = \"foo\"; }` evaluates to `[ \"x\" \"y\" ]`.\
+= 1; x = \"foo\"; }` evaluates to `[ \"x\" \"y\" ]`.
+
+Has `O(n log n)` time complexity, where `n` is number of attributes in the *set*.\
                 "
                 ),
                 impure_only: false,

--- a/crates/ide/src/ide/hover.rs
+++ b/crates/ide/src/ide/hover.rs
@@ -387,6 +387,8 @@ mod tests {
                 Return the first element of a list; abort evaluation if the argument
                 isn’t a list or is an empty list. You can test whether a list is
                 empty by comparing it with `[]`.
+
+                Has constant time complexity.
             "#]],
         );
     }
@@ -404,6 +406,8 @@ mod tests {
                 Return the first element of a list; abort evaluation if the argument
                 isn’t a list or is an empty list. You can test whether a list is
                 empty by comparing it with `[]`.
+
+                Has constant time complexity.
             "#]],
         );
     }
@@ -422,6 +426,8 @@ mod tests {
                 Return the first element of a list; abort evaluation if the argument
                 isn’t a list or is an empty list. You can test whether a list is
                 empty by comparing it with `[]`.
+
+                Has constant time complexity.
             "#]],
         );
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749619289,
-        "narHash": "sha256-qX6gXVjaCXXbcn6A9eSLUf8Fm07MgPGe5ir3++y2O1Q=",
+        "lastModified": 1784115452,
+        "narHash": "sha256-BoYPdqk6jlKXy+DyUzyGV/CtRGfAhk2MmIgBhsemTGI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f72be405a10668b8b00937b452f2145244103ebc",
+        "rev": "35d3407a3816f3b341d8cf1d60abaf2b7b8166ac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Follows #99

Reflects documentation changes for nix primops introduced in NixOS/nix@f88c306340939391bdec8e3cd9d753c4f6f5ccf2

Also updates nixpkgs to utilize 2.35.1 (`nixVersions.latest`) for tests.